### PR TITLE
Goron Mines Entrance Changes PR review

### DIFF
--- a/Generator/Assets/Flags.cs
+++ b/Generator/Assets/Flags.cs
@@ -70,8 +70,8 @@ namespace TPRandomizer.Assets
             { 0x9, 0x7E }, // Jovani Chest CS
             { 0x3, 0xA7 }, // Unlock Jumps to top of Sanctuary
             { 0x3, 0x9A }, // Kakariko Village intro CS.
-           // { 0x9, 0x50 }, // Set flag for Midna breaking Barrier CS.
-            { 0xA, 0x7F} , // Mirror Raised Cutscene Flag (Places Boar at desert entrance)
+            // { 0x9, 0x50 }, // Set flag for Midna breaking Barrier CS.
+            { 0xA, 0x7F }, // Mirror Raised Cutscene Flag (Places Boar at desert entrance)
         };
 
         /// <summary>
@@ -382,7 +382,7 @@ namespace TPRandomizer.Assets
             { 0x8, 0x49 }, // Snowpeak summit cs.
             { 0x8, 0x45 }, // Snowpeak Summit intro CS.
         };
-         public static readonly byte[,] OpenDMTRegionFlags = new byte[,]
+        public static readonly byte[,] OpenDMTRegionFlags = new byte[,]
         {
             { 0x3, 0x81 }, // moved death mountain rock to exit
         };
@@ -402,7 +402,7 @@ namespace TPRandomizer.Assets
                 { 7, SmallKeyRegionFlags },
                 { 8, BigKeyRegionFlags },
                 { 9, MapAndCompassRegionFlags },
-                 { 13, OpenLakebedRegionFlags },
+                { 13, OpenLakebedRegionFlags },
                 { 14, OpenArbitersRegionFlags },
                 { 15, OpenSnowpeakRegionFlags },
                 { 16, OpenToTRegionFlags },
@@ -437,7 +437,7 @@ namespace TPRandomizer.Assets
             { 0x38, 0x80 }, // Talked to Jovani after defeating Poe.
             { 0x22, 0x8 }, // Talked to Yeto on top of the mountain after clearing SPR
             { 0x3B, 0x40 }, // Won Snowboard race against Yeto.
-            { 0x2F, 0x80 }, // Talked to Goron outside East Castle Town 
+            { 0x2F, 0x80 }, // Talked to Goron outside East Castle Town
         };
 
         /// <summary>
@@ -606,14 +606,14 @@ namespace TPRandomizer.Assets
             /* 9 */RandomizerSettings.mapAndCompassSettings == MapAndCompassSettings.Start_With,
             /* 10 */RandomizerSettings.castleRequirements == CastleRequirements.Open,
             /* 11 */RandomizerSettings.palaceRequirements == PalaceRequirements.Open,
-            /* 12 */RandomizerSettings.MinesEntrance == MinesEntrance.NoWrestling,
+            /* 12 */RandomizerSettings.goronMinesEntrance == GoronMinesEntrance.NoWrestling,
             /* 13 */RandomizerSettings.skipLakebedEntrance,
             /* 14 */RandomizerSettings.skipArbitersEntrance,
             /* 15 */RandomizerSettings.skipSnowpeakEntrance,
             /* 16 */RandomizerSettings.totEntrance == TotEntrance.Open,
             /* 17 */RandomizerSettings.skipCityEntrance,
             /* 18 */RandomizerSettings.totEntrance == TotEntrance.OpenGrove,
-            /* 19 */RandomizerSettings.MinesEntrance == MinesEntrance.Open,
+            /* 19 */RandomizerSettings.goronMinesEntrance == GoronMinesEntrance.Open,
         };
     }
 }

--- a/Generator/Logic/SSettingsEnums.cs
+++ b/Generator/Logic/SSettingsEnums.cs
@@ -76,11 +76,11 @@ namespace TPRandomizer.SSettings.Enums
         OpenGrove = 1,
         Open = 2,
     }
-    public enum MinesEntrance
+
+    public enum GoronMinesEntrance
     {
         Closed = 0,
         NoWrestling = 1,
         Open = 2,
     }
-
 }

--- a/Generator/Logic/SeedGenResults.cs
+++ b/Generator/Logic/SeedGenResults.cs
@@ -321,7 +321,7 @@ namespace TPRandomizer
             result.Add("modifyShopModels", sSettings.modifyShopModels);
             result.Add("trapFrequency", sSettings.trapFrequency.ToString());
             result.Add("barrenDungeons", sSettings.barrenDungeons);
-            result.Add("MinesEntrance", sSettings.MinesEntrance.ToString());
+            result.Add("goronMinesEntrance", sSettings.goronMinesEntrance.ToString());
             result.Add("skipLakebedEntrance", sSettings.skipLakebedEntrance);
             result.Add("skipArbitersEntrance", sSettings.skipArbitersEntrance);
             result.Add("skipSnowpeakEntrance", sSettings.skipSnowpeakEntrance);

--- a/Generator/Logic/SharedSettings.cs
+++ b/Generator/Logic/SharedSettings.cs
@@ -40,7 +40,7 @@ namespace TPRandomizer
         public bool modifyShopModels { get; set; }
         public TrapFrequency trapFrequency { get; set; }
         public bool barrenDungeons { get; set; }
-        public  MinesEntrance MinesEntrance { get; set; }
+        public GoronMinesEntrance goronMinesEntrance { get; set; }
         public bool skipLakebedEntrance { get; set; }
         public bool skipArbitersEntrance { get; set; }
         public bool skipSnowpeakEntrance { get; set; }
@@ -82,6 +82,18 @@ namespace TPRandomizer
             modifyShopModels = processor.NextBool();
             trapFrequency = (TrapFrequency)processor.NextInt(3);
             barrenDungeons = processor.NextBool();
+            if (version >= 2)
+            {
+                // `goronMinesEntrance` changed from a checkbox to a select
+                goronMinesEntrance = (GoronMinesEntrance)processor.NextInt(2);
+            }
+            else
+            {
+                bool skipMinesEntrance = processor.NextBool();
+                goronMinesEntrance = skipMinesEntrance
+                    ? GoronMinesEntrance.NoWrestling
+                    : GoronMinesEntrance.Closed;
+            }
             skipLakebedEntrance = processor.NextBool();
             skipArbitersEntrance = processor.NextBool();
             skipSnowpeakEntrance = processor.NextBool();
@@ -100,16 +112,6 @@ namespace TPRandomizer
             {
                 // `instantText` was added as an option in version 1
                 instantText = processor.NextBool();
-            }
-             if (version >= 2)
-            {
-                // `MinesEntrance` was added as an option in version 2
-                MinesEntrance = (MinesEntrance) processor.NextInt(2);
-            }
-            else
-            {
-                bool MinesOpen = processor.NextBool();
-                MinesEntrance = MinesOpen ? MinesEntrance.Open : MinesEntrance.Closed;
             }
             // We sort these lists so that the order which the UI happens to
             // pass the data up does not affect anything.

--- a/Generator/Randomizer.cs
+++ b/Generator/Randomizer.cs
@@ -411,8 +411,8 @@ namespace TPRandomizer
             if (SSettings.modifyShopModels)
                 part2Settings.Add("modifyShopModels", SSettings.modifyShopModels);
 
-            if (SSettings.MinesEntrance != MinesEntrance.Closed)
-                part2Settings.Add("MinesEntrance", SSettings.MinesEntrance);
+            if (SSettings.goronMinesEntrance != GoronMinesEntrance.Closed)
+                part2Settings.Add("goronMinesEntrance", SSettings.goronMinesEntrance);
             if (SSettings.skipLakebedEntrance)
                 part2Settings.Add("skipLakebedEntrance", SSettings.skipLakebedEntrance);
             if (SSettings.skipArbitersEntrance)

--- a/Generator/World/Rooms/Overworld/Eldin Province/Death Mountain Volcano.json
+++ b/Generator/World/Rooms/Overworld/Eldin Province/Death Mountain Volcano.json
@@ -7,7 +7,7 @@
     "NeighbourRequirements": 
     [
         "true",
-        "Iron_Boots and ((CanDefeatGoron) or (Setting.MinesEntrance equals Open))"
+        "Iron_Boots and ((CanDefeatGoron) or (Setting.goronMinesEntrance equals Open))"
     ],
     "Checks": [""], 
     "Region": "Death Mountain"

--- a/docs/formats/s-settings-history.md
+++ b/docs/formats/s-settings-history.md
@@ -6,14 +6,17 @@ Initial version.
 
 ## Version 1
 
-`skipToTEntrance` changed from a checkbox to a select with the options "Closed", "Open Grove", and "Open". The old value of `false` maps to "Closed", and the old value of `true` maps to "Open".
+`skipToTEntrance` changed from a checkbox to a select with the options "Closed", "Open Grove", and "Open".
+The old value of `false` maps to "Closed", and the old value of `true` maps to "Open".
 Setting was also renamed from `skipToTEntrance` to `totEntrance`.
 It is still at the same location in the settings string, but it is now 2 bits long instead of 1.
 
-`instantText` was added as a setting 
+`instantText` was added.
+It is a checkbox.
 
 ## Version 2
 
-`skipMinesEntrance` changed from a checkbox to a select with the options "Closed", "Open", and "Fast DMT". The old value of `false` maps to "Closed", and the old value of `true` maps to "Open".
-Setting was also renamed from `skipMinesEntrance` to `MinesEntrance`.
+`skipMinesEntrance` changed from a checkbox to a select with the options "Closed", "NoWrestling", and "Open".
+The old value of `false` maps to "Closed", and the old value of `true` maps to "Open".
+Setting was also renamed from `skipMinesEntrance` to `goronMinesEntrance`.
 It is still at the same location in the settings string, but it is now 2 bits long instead of 1.

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -440,8 +440,7 @@
                   name="Instant Text"
                   value=""
                 />
-                <label for="instantTextCheckbox">
-                  Instant Message Text </label
+                <label for="instantTextCheckbox"> Instant Message Text </label
                 ><br />
               </div>
             </fieldset>
@@ -516,21 +515,7 @@
           <div class="tabColumn">
             <fieldset id="dungeonRequirementsFieldset">
               <legend>Dungeon Entrance Settings</legend>
-              
-              <div
-              class="selectGroup"
-              style="margin-top: 8px"
-              data-tooltip-text="'Closed': If checked, Link will  have to wrestle Gor Coron to enter Goron Mines.&#0010;&#0010;'NoWrestling': If checked, Link will not have to wrestle Gor Coron to enter Goron Mines &#0010;&#0010;'Open': all changes of 'NoWrestling' are applied. Additionally, the player will have the rock of dmt moved'"
-              data-tooltip-position="left"
-            >
-              <label for="">Goron Mines Entrance</label
-              ><br />
-              <select name="Goron Mines Entrance" id="MinesEntranceFieldset">
-                <option value="0">Closed</option>
-                <option value="1">NoWrestling </option>
-                <option value="2">Open</option>
-              </select>
-            </div>
+
               <div
                 data-tooltip-text="If checked, the rock in front of the entrance to Lakebed Temple is destroyed.&#0010;"
                 data-tooltip-position="left"
@@ -586,6 +571,22 @@
                 <label for="cityEntranceCheckbox">
                   City Does Not Require Filled Skybook </label
                 ><br />
+              </div>
+              <div
+                class="selectGroup"
+                style="margin-top: 8px"
+                data-tooltip-text="'Closed': The player must wrestle Gor Coron to enter Goron Mines.&#0010;&#0010;'NoWrestling': The player will not have to wrestle Gor Coron to enter Goron Mines.&#0010;&#0010;'Open': All changes of 'NoWrestling' are applied. Additionally, the player will be able to immediately use the elevator to reach the top of Death Mountain."
+                data-tooltip-position="left"
+              >
+                <label for="">Goron Mines Entrance</label><br />
+                <select
+                  name="Goron Mines Entrance"
+                  id="goronMinesEntranceFieldset"
+                >
+                  <option value="0">Closed</option>
+                  <option value="1">NoWrestling</option>
+                  <option value="2">Open</option>
+                </select>
               </div>
               <div
                 class="selectGroup"

--- a/packages/client/js/shared.js
+++ b/packages/client/js/shared.js
@@ -366,7 +366,7 @@
       { id: 'modifyShopModelsCheckbox' },
       { id: 'foolishItemFieldset', bitLength: 3 },
       { id: 'barrenCheckbox' },
-      { id: 'MinesEntranceFieldset', bitLength: 2 },
+      { id: 'goronMinesEntranceFieldset', bitLength: 2 },
       { id: 'lakebedEntranceCheckbox' },
       { id: 'arbitersEntranceCheckbox' },
       { id: 'snowpeakEntranceCheckbox' },
@@ -721,6 +721,20 @@
     processBasic({ id: 'shopModelsShowTheReplacedItem' });
     processBasic({ id: 'trapItemsFrequency', bitLength: 3 });
     processBasic({ id: 'barrenDungeons' });
+    if (version >= 2) {
+      // `goronMinesEntrance` changed from a checkbox to a select
+      processBasic({ id: 'goronMinesEntrance', bitLength: 2 });
+    } else {
+      const goronMinesEntrance = {
+        closed: 0,
+        noWrestling: 1,
+        open: 2,
+      };
+      const skipMinesEntrance = processor.nextBoolean();
+      res.goronMinesEntrance = skipMinesEntrance
+        ? goronMinesEntrance.noWrestling
+        : goronMinesEntrance.closed;
+    }
     processBasic({ id: 'skipLakebedEntrance' });
     processBasic({ id: 'skipArbitersEntrance' });
     processBasic({ id: 'skipSnowpeakEntrance' });
@@ -740,19 +754,6 @@
     if (version >= 1) {
       // `instantText' added as an option in version 1
       processBasic({ id: 'instantText' });
-    }
-
-    if (version >= 2) {
-      // `MineEntrance` changed from a checkbox to a select
-      processBasic({ id: 'MinesEntrance', bitLength: 2 });
-    } else {
-      const MinesEntrance = {
-        closed: 0,
-        NoWrestling : 1,
-        Open : 2,
-      };
-      const MinesOpen = processor.nextBoolean();
-    res.MinesEntrance = MinesOpen ? MinesEntrance.NoWrestling : MinesEntrance.closed;
     }
 
     res.startingItems = processor.nextEolList(9);

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -331,7 +331,8 @@ document
   .getElementById('barrenCheckbox')
   .addEventListener('click', setSettingsString);
 document;
-document.getElementById('MinesEntranceFieldset').onchange = setSettingsString;
+document.getElementById('goronMinesEntranceFieldset').onchange =
+  setSettingsString;
 document
   .getElementById('lakebedEntranceCheckbox')
   .addEventListener('click', setSettingsString);
@@ -346,7 +347,7 @@ document.getElementById('totEntranceFieldset').onchange = setSettingsString;
 document
   .getElementById('cityEntranceCheckbox')
   .addEventListener('click', setSettingsString);
-  document
+document
   .getElementById('instantTextCheckbox')
   .addEventListener('click', setSettingsString);
 document
@@ -456,7 +457,7 @@ function setSettingsString() {
   settingsStringRaw[30] = document.getElementById('barrenCheckbox').checked;
 
   settingsStringRaw[31] = document.getElementById(
-    'MinesEntranceFieldset'
+    'goronMinesEntranceFieldset'
   ).selectedIndex;
   settingsStringRaw[32] = document.getElementById(
     'lakebedEntranceCheckbox'
@@ -628,7 +629,7 @@ var arrayOfSettingsItems = [
   'increaseWalletCheckbox',
   'modifyShopModelsCheckbox',
   'barrenCheckbox',
-  'MinesEntranceFieldset',
+  'goronMinesEntranceFieldset',
   'lakebedEntranceCheckbox',
   'arbitersEntranceCheckbox',
   'snowpeakEntranceCheckbox',
@@ -1178,7 +1179,7 @@ function populateSSettings(s) {
   );
   $('#foolishItemFieldset').val(s.trapItemsFrequency);
   $('#barrenCheckbox').prop('checked', s.barrenDungeons);
-  $('#MinesEntranceFieldset').val(s.MinesEntrance);
+  $('#goronMinesEntranceFieldset').val(s.goronMinesEntrance);
   $('#lakebedEntranceCheckbox').prop('checked', s.skipLakebedEntrance);
   $('#arbitersEntranceCheckbox').prop('checked', s.skipArbitersEntrance);
   $('#snowpeakEntranceCheckbox').prop('checked', s.skipSnowpeakEntrance);


### PR DESCRIPTION
- Rename MinesEntrance everywhere to goronMinesEntrance (mainly to match starting with lowercase letter).
- Format files
- Adjust hover text for setting in UI and move position to be next to totEntrance select in the UI.
- Update s-settings documentation.
- Fix issue with parsing settings strings of version 1 or lower.