### PR TITLE
Add hint for which wing of PoT the big key is in

### DIFF
--- a/Generator/Assets/HintDistributions/drehenoptional.jsonc
+++ b/Generator/Assets/HintDistributions/drehenoptional.jsonc
@@ -28,16 +28,15 @@
   },
   "removeChecks": {
     "Palace of Twilight Collect Both Sols": ["always"],
-	"Forest Temple Gale Boomerang": ["sometimes"],
+    "Forest Temple Gale Boomerang": ["sometimes"],
     "City in The Sky Aeralfos Chest": ["sometimes"]
   },
-  "removeItems": {
-  },
+  "removeItems": {},
   //
   "groups": {
     "overworld": ["alias:overworldZones"],
     "requiredDungeons": ["alias:requiredDungeons"],
-	"unrequiredDungeons": ["alias:unrequiredDungeons"]
+    "unrequiredDungeons": ["alias:unrequiredDungeons"]
   },
   // Special hints generated right after Always hints are generated. These are
   // created even if the dungeon is hinted barren or the check is already hinted
@@ -53,7 +52,7 @@
         }
       }
     },
-	{
+    {
       "spot": "forest_temple_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -64,8 +63,8 @@
         }
       }
     },
-	//
-	{
+    //
+    {
       "spot": "goron_mines_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -76,8 +75,8 @@
         }
       }
     },
-	//
-	{
+    //
+    {
       "spot": "lakebed_temple_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -88,8 +87,8 @@
         }
       }
     },
-	//
-	{
+    //
+    {
       "spot": "arbiters_grounds_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -100,7 +99,7 @@
         }
       }
     },
-	//
+    //
     {
       "spot": "snowpeak_ruins_sign",
       "hintDef": {
@@ -132,7 +131,7 @@
         ]
       }
     },
-	{
+    {
       "spot": "snowpeak_ruins_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -143,7 +142,7 @@
         }
       }
     },
-	//
+    //
     {
       "spot": "temple_of_time_sign",
       "hintDef": {
@@ -154,7 +153,7 @@
         }
       }
     },
-	{
+    {
       "spot": "temple_of_time_sign",
       "groupId": "unrequiredDungeons",
       "hintDef": {
@@ -165,61 +164,45 @@
         }
       }
     },
-	//
-	{
+    //
+    {
       "spot": "city_in_the_sky_sign",
       "groupId": "unrequiredDungeons",
-      "hintDef": {
-        "hintType": "location",
-        "options": {
-          "canHintHintedBarrenChecks": true,
-          "validChecks": ["City in The Sky Argorok Heart Container"]
+      "hintDef": [
+        {
+          "hintType": "location",
+          "options": {
+            "canHintHintedBarrenChecks": true,
+            "validChecks": ["City in The Sky Argorok Heart Container"]
+          }
         }
-      }
+      ]
     },
-	//
-	{
+    //
+    {
       "spot": "Palace_of_Twilight_Sign",
       "hintDef": {
         "hintType": "location",
         "options": {
           "canHintHintedBarrenChecks": true,
-          "validChecks": ["Palace of Twilight Collect Both Sols"]
+          "validChecks": ["Palace of Twilight Collect Both Sols"],
+          "checkStatusDisplay": "required_info"
         }
       }
     },
     {
-      "spot": "palace_of_twilight_sign",
+      "spot": "Palace_of_Twilight_Sign",
       "hintDef": {
-        "maxPicks": 1,
-        "hintDef": [
-          {
-            "hintType": "location",
-            "options": {
-              "canHintHintedBarrenChecks": true,
-              "validChecks": [
-                "Palace of Twilight Big Key Chest",
-                "Palace of Twilight Central First Room Chest",
-                "Palace of Twilight Central Outdoor Chest",
-                "Palace of Twilight Central Tower Chest",
-                "Palace of Twilight East Wing First Room East Alcove Chest",
-                "Palace of Twilight East Wing First Room North Small Chest",
-                "Palace of Twilight East Wing First Room West Alcove Chest",
-                "Palace of Twilight East Wing First Room Zant Head Chest",
-                "Palace of Twilight East Wing Second Room Northeast Chest",
-                "Palace of Twilight East Wing Second Room Northwest Chest",
-                "Palace of Twilight East Wing Second Room Southeast Chest",
-                "Palace of Twilight East Wing Second Room Southwest Chest",
-                "Palace of Twilight West Wing Chest Behind Wall of Darkness",
-                "Palace of Twilight West Wing First Room Central Chest",
-                "Palace of Twilight West Wing Second Room Central Chest",
-                "Palace of Twilight West Wing Second Room Lower South Chest",
-                "Palace of Twilight West Wing Second Room Southeast Chest"
-              ],
-              "validItems": ["Palace_of_Twilight_Big_Key"]
-            }
-          }
-        ]
+        "hintType": "item",
+        "options": {
+          "validItems": ["Palace_of_Twilight_Big_Key"],
+          "areaType": "category",
+          "validCategories": [
+            "Palace_of_Twilight_West_Wing",
+            "Palace_of_Twilight_Central_Tower",
+            "Palace_of_Twilight_East_Wing"
+          ]
+        }
       }
     }
   ],
@@ -248,7 +231,6 @@
             "saveToVar": "HintCopies",
             "options": {
               "areaType": "category"
-
             }
           },
           {
@@ -280,9 +262,9 @@
             "hintDef": [
               {
                 "hintType": "location",
-                "namedOrder": "random",				  
+                "namedOrder": "random",
                 "namedProbability": 1,
-                "minCopies": 1,					
+                "minCopies": 1,
                 "options": {
                   "markAsSometimes": true,
                   "namedChecks": [
@@ -291,15 +273,15 @@
                     "Goron Mines Main Magnet Room Top Chest",
                     "City in The Sky West Wing First Chest",
                     "City in The Sky Chest Behind North Fan",
-				          	"Palace of Twilight Big Key Chest"
+                    "Palace of Twilight Big Key Chest"
                   ]
                 }
               },
               {
                 "hintType": "location",
-                "namedOrder": "random",				  
+                "namedOrder": "random",
                 "namedProbability": 1,
-                "minCopies": 1,				
+                "minCopies": 1,
                 "options": {
                   "markAsSometimes": true,
                   "namedChecks": [

--- a/Generator/Assets/HintDistributions/drehenoptional.jsonc
+++ b/Generator/Assets/HintDistributions/drehenoptional.jsonc
@@ -195,6 +195,7 @@
       "hintDef": {
         "hintType": "item",
         "options": {
+          "canHintHintedBarrenChecks": true,
           "validItems": ["Palace_of_Twilight_Big_Key"],
           "areaType": "category",
           "validCategories": [

--- a/Generator/Hints/HintCategory.cs
+++ b/Generator/Hints/HintCategory.cs
@@ -29,6 +29,9 @@ namespace TPRandomizer.Hints
         Snowpeak_Beyond_This_Point = 18,
         Golden_Wolf = 19,
         Lantern_Chests = 20,
+        Palace_of_Twilight_West_Wing = 21,
+        Palace_of_Twilight_Central_Tower = 22,
+        Palace_of_Twilight_East_Wing = 23,
     }
 
     public class HintCategoryUtils
@@ -347,6 +350,42 @@ namespace TPRandomizer.Hints
                         "Lake Lantern Cave End Lantern Chest",
                     }
                 },
+                {
+                    HintCategory.Palace_of_Twilight_West_Wing,
+                    new[]
+                    {
+                        "Palace of Twilight West Wing Chest Behind Wall of Darkness",
+                        "Palace of Twilight West Wing First Room Central Chest",
+                        "Palace of Twilight West Wing Second Room Central Chest",
+                        "Palace of Twilight West Wing Second Room Lower South Chest",
+                        "Palace of Twilight West Wing Second Room Southeast Chest"
+                    }
+                },
+                {
+                    HintCategory.Palace_of_Twilight_Central_Tower,
+                    new[]
+                    {
+                        "Palace of Twilight Big Key Chest",
+                        "Palace of Twilight Central First Room Chest",
+                        "Palace of Twilight Central Outdoor Chest",
+                        "Palace of Twilight Central Tower Chest",
+                        "Palace of Twilight Zant Heart Container"
+                    }
+                },
+                {
+                    HintCategory.Palace_of_Twilight_East_Wing,
+                    new[]
+                    {
+                        "Palace of Twilight East Wing First Room East Alcove Chest",
+                        "Palace of Twilight East Wing First Room North Small Chest",
+                        "Palace of Twilight East Wing First Room West Alcove Chest",
+                        "Palace of Twilight East Wing First Room Zant Head Chest",
+                        "Palace of Twilight East Wing Second Room Northeast Chest",
+                        "Palace of Twilight East Wing Second Room Northwest Chest",
+                        "Palace of Twilight East Wing Second Room Southeast Chest",
+                        "Palace of Twilight East Wing Second Room Southwest Chest",
+                    }
+                }
             };
 
         static HintCategoryUtils()
@@ -373,6 +412,12 @@ namespace TPRandomizer.Hints
                 { HintCategory.Golden_Wolf, "Golden_Wolf" },
                 { HintCategory.Lantern_Chests, "Lantern_Chests" },
                 { HintCategory.Forest_Temple_West_Wing, "Forest_Temple_West_Wing" },
+                { HintCategory.Palace_of_Twilight_West_Wing, "Palace_of_Twilight_West_Wing" },
+                {
+                    HintCategory.Palace_of_Twilight_Central_Tower,
+                    "Palace_of_Twilight_Central_Tower"
+                },
+                { HintCategory.Palace_of_Twilight_East_Wing, "Palace_of_Twilight_East_Wing" },
             };
 
             strToEnum = new();

--- a/Generator/Translations/Translations.fr.resx
+++ b/Generator/Translations/Translations.fr.resx
@@ -141,10 +141,6 @@
     <value>le {cs}Loup Doré{ce}</value>
     <comment></comment>
   </data>
-    <data name="area.category.lantern_chests" xml:space="preserve">
-    <value>$(ap:dans)un {cs}Coffre Lanterne qui apparait{ce}</value>
-    <comment></comment>
-  </data>
   <data name="area.category.grotto" xml:space="preserve">
     <value>$(ap:dans)une {cs}Grotte secrète{ce}</value>
     <comment></comment>
@@ -155,6 +151,10 @@
   </data>
   <data name="area.category.grotto$plural" xml:space="preserve">
     <value>$(ap:dans,plural)les {cs}Grottes secrètes{ce}</value>
+    <comment></comment>
+  </data>
+  <data name="area.category.lantern_chests" xml:space="preserve">
+    <value>$(ap:dans)un {cs}Coffre Lanterne qui apparait{ce}</value>
     <comment></comment>
   </data>
   <data name="area.category.llc_lantern_chests" xml:space="preserve">

--- a/Generator/Translations/Translations.resx
+++ b/Generator/Translations/Translations.resx
@@ -149,10 +149,6 @@
     <value>$(ap:with)the {cs}Golden Wolf{ce}</value>
     <comment></comment>
   </data>
-  <data name="area.category.lantern_chests" xml:space="preserve">
-    <value>a {cs}spawnable lantern chests{ce}</value>
-    <comment></comment>
-  </data>
   <data name="area.category.grotto" xml:space="preserve">
     <value>a {cs}Grotto{ce}</value>
     <comment></comment>
@@ -163,6 +159,10 @@
   </data>
   <data name="area.category.grotto$plural" xml:space="preserve">
     <value>$(plural)Grottos</value>
+    <comment></comment>
+  </data>
+  <data name="area.category.lantern_chests" xml:space="preserve">
+    <value>a {cs}spawnable lantern chests{ce}</value>
     <comment></comment>
   </data>
   <data name="area.category.llc_lantern_chests" xml:space="preserve">

--- a/Generator/Translations/Translations.resx
+++ b/Generator/Translations/Translations.resx
@@ -197,6 +197,18 @@
     <value>$(ap:behind,plural)Owl Statues</value>
     <comment></comment>
   </data>
+  <data name="area.category.palace_of_twilight_central_tower" xml:space="preserve">
+    <value>the {cs}central tower{ce}</value>
+    <comment></comment>
+  </data>
+  <data name="area.category.palace_of_twilight_east_wing" xml:space="preserve">
+    <value>the {cs}east wing{ce}</value>
+    <comment></comment>
+  </data>
+  <data name="area.category.palace_of_twilight_west_wing" xml:space="preserve">
+    <value>the {cs}west wing{ce}</value>
+    <comment></comment>
+  </data>
   <data name="area.category.southern_desert" xml:space="preserve">
     <value>the {cs}southern desert{ce}</value>
     <comment></comment>


### PR DESCRIPTION
- Still needs French resources added. Once you add a resource, you should run `yarn sort` from the root directory to normalize the translation files.
- I changed it to where the Collect Both Sols hint indicates if the check is required (mainly to show it was possible and since the current Always hint does that), but you can remove that line to revert to the default behavior.